### PR TITLE
Update Hotels_IndexDefinition.JSON

### DIFF
--- a/hotels/Hotels_IndexDefinition.JSON
+++ b/hotels/Hotels_IndexDefinition.JSON
@@ -256,7 +256,7 @@
 				"boost":5
 			 }
 		  ],
-		  "functionAggregation":0
+		  "functionAggregation":"sum"
 	   },
 	   {
 		  "name":"renovatedAndHighlyRated",
@@ -288,7 +288,7 @@
 				"boost":10
 			 }
 		  ],
-		  "functionAggregation":0
+		  "functionAggregation":"sum"
 	   }
 	],
 	"defaultScoringProfile":"boostByField",
@@ -311,7 +311,7 @@
 	   
 	],
 	"similarity":{
-	   "@odata.type":"#Microsoft.Azure.Search.ClassicSimilarity"
+	   "@odata.type":"#Microsoft.Azure.Search.BM25Similarity"
 	},
 	"encryptionKey":null,
 	"@odata.etag":"\"0x8D842F5970E055B\""


### PR DESCRIPTION
Fixed a couple minor errors I saw when creating a new index using the hotels index definition against a new service with 2023-11-01.

Suggesting we default to BM25 similarity since Classic is no longer supported for new services.